### PR TITLE
Set theme name to Darcula

### DIFF
--- a/.ci_funcs.sh
+++ b/.ci_funcs.sh
@@ -25,7 +25,7 @@ ci_script() {
 
     # enable the theme in user-settings
     mkdir -p $(dirname $THEME_SETTINGS)
-    printf "%s\n" "{" "    \"theme\": \"theme-darcula\"" "}" > $THEME_SETTINGS
+    printf "%s\n" "{" "    \"theme\": \"Darcula\"" "}" > $THEME_SETTINGS
 
     # run a test of the main JupyterLab app with the theme enabled
     python -m jupyterlab.browser_check

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const style = "@telamonian/theme-darcula/index.css";
 
     manager.register({
-      name: "theme-darcula",
+      name: "Darcula",
       isLight: false,
       themeScrollbars: true,
       load: () => manager.loadCSS(style),


### PR DESCRIPTION
For now the theme appears as "theme-darcula", which looks a bit different compared to the default themes:

![image](https://user-images.githubusercontent.com/591645/82129073-71fad380-97c0-11ea-9311-44d1dbaa1b62.png)

It would be nice to name the theme as "Darcula", so it shows up nicely in the list.

