### PR TITLE
Do not include the theme CSS as a default style file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/telamonian/theme-darcula.git"


### PR DESCRIPTION
The default style files are automatically put on the page in JupyterLab. Removing this line ensures that JLab can appropriately add *and remove* the theme CSS as appropriate.

Fixes #32 

See also https://github.com/jupyterlab/jupyterlab/pull/10381 for a similar change in upstream JLab themes.