### PR TITLE
Remove the `jupyterlab` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab>=3.0.0rc13,==3.*",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
So the prebuilt extension can be installed without pulling `jupyterlab` as a dependency.