### PR TITLE
Fix illegible white on yellow text of stacktrace

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -16,3 +16,10 @@ pre {
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
 }
+
+/* fix illegible yellow background in exception stacktrace */
+:where(.jp-RenderedText[data-mime-type='application/vnd.jupyter.stderr']
+    pre
+    .ansi-yellow-bg) {
+  color: black;
+}


### PR DESCRIPTION
Higlighted stacktrace background color is inherited from default theme, which is bright yellow,
while default text foreground becomes also bright in dark themes, thus becoming unreadable.


before

![image](https://user-images.githubusercontent.com/12046452/196002949-cae3dd3b-9c91-4cb2-9128-09bcdb3e3a2c.png)

after

![image](https://user-images.githubusercontent.com/12046452/196002984-369a5120-ee66-415a-9139-b832331235b7.png)

For reference, there is [analogous PR](https://github.com/jupyterlab/jupyterlab/pull/13249) to default JupyterLab dark theme
